### PR TITLE
Add resources definition for spark custom profiles

### DIFF
--- a/applications/jupyterhub/bases/custom-profiles/jupyterhub-singleuser-profiles.yaml
+++ b/applications/jupyterhub/bases/custom-profiles/jupyterhub-singleuser-profiles.yaml
@@ -43,6 +43,9 @@ profiles:
     PYSPARK_DRIVER_PYTHON_OPTS: "notebook"
     SPARK_HOME: '/opt/app-root/lib/python3.6/site-packages/pyspark/'
     PYTHONPATH: '$PYTHONPATH:/opt/app-root/lib/python3.6/site-packages/:/opt/app-root/lib/python3.6/site-packages/pyspark/python/:/opt/app-root/lib/python3.6/site-packages/pyspark/python/lib/py4j-0.8.2.1-src.zip'
+  resources:
+    mem_limit: 2Gi
+    cpu_limit: 1
   services:
     spark:
       template: jupyterhub-spark-operator-configmap


### PR DESCRIPTION
A previous change to the jupyterhub single user profiles code made it
necessary to specify the hardware resources in each custom profile. This
change adds the resource definitions for the spark custom profile.