### PR TITLE
WIP: Update singleuser profiles for ODH 0.5.2 release

### DIFF
--- a/applications/jupyterhub/bases/custom-profiles/jupyterhub-singleuser-profiles.yaml
+++ b/applications/jupyterhub/bases/custom-profiles/jupyterhub-singleuser-profiles.yaml
@@ -50,10 +50,16 @@ profiles:
     spark:
       template: jupyterhub-spark-operator-configmap
       parameters:
-        WORKER_NODES: 2
-        MASTER_NODES: 1
-        MEMORY: 2Gi
-        CPU: 1
+        WORKER_NODES: '2'
+        MASTER_NODES: '1'
+        MASTER_MEMORY_LIMIT: '2Gi'
+        MASTER_CPU_LIMIT: '1'
+        MASTER_MEMORY_REQUEST: '2Gi'
+        MASTER_CPU_REQUEST: '1'
+        WORKER_MEMORY_LIMIT: '2Gi'
+        WORKER_CPU_LIMIT: '1'
+        WORKER_MEMORY_REQUEST: '2Gi'
+        WORKER_CPU_REQUEST: '1'
         SPARK_IMAGE: quay.io/radanalyticsio/openshift-spark:2.4-latest
       return:
         SPARK_CLUSTER: 'metadata.name'
@@ -71,23 +77,19 @@ profiles:
     PYTHONPATH: '$PYTHONPATH:/opt/app-root/lib/python3.6/site-packages/:/opt/app-root/lib/python3.6/site-packages/pyspark/python/:/opt/app-root/lib/python3.6/site-packages/pyspark/python/lib/py4j-0.8.2.1-src.zip'
   services:
     spark:
-      resources:
-      - name: spark-cluster-template
-        path: notebookPodServiceTemplate
-      - name: spark-cluster-template
-        path: sparkClusterTemplate
+      template: jupyterhub-spark-operator-configmap
       configuration:
-        worker_nodes: '2'
-        master_nodes: '1'
-        master_memory_limit: '2Gi'
-        master_cpu_limit: '1'
-        master_memory_request: '2Gi'
-        master_cpu_request: '1'
-        worker_memory_limit: '2Gi'
-        worker_cpu_limit: '1'
-        worker_memory_request: '2Gi'
-        worker_cpu_request: '1'
-        spark_image: 'quay.io/radanalyticsio/openshift-spark-py36:2.4.5-2'
+        WORKER_NODES: '2'
+        MASTER_NODES: '1'
+        MASTER_MEMORY_LIMIT: '2Gi'
+        MASTER_CPU_LIMIT: '1'
+        MASTER_MEMORY_REQUEST: '2Gi'
+        MASTER_CPU_REQUEST: '1'
+        WORKER_MEMORY_LIMIT: '2Gi'
+        WORKER_CPU_LIMIT: '1'
+        WORKER_MEMORY_REQUEST: '2Gi'
+        WORKER_CPU_REQUEST: '1'
+        SPARK_IMAGE: 'quay.io/radanalyticsio/openshift-spark-py36:2.4.5-2'
       return:
         SPARK_CLUSTER: 'metadata.name'
 

--- a/applications/jupyterhub/bases/jupyterhub/jupyterhub.yaml
+++ b/applications/jupyterhub/bases/jupyterhub/jupyterhub.yaml
@@ -18,6 +18,7 @@ spec:
     s3_endpoint_url: https://s3.upshift.redhat.com
     registry: "quay.io"
     repository: "odh-jupyterhub"
+    jupyterhub_img_tag: 3.0.7-df59c25
     jupyterhub_db_version: "9.5"
     jupyterhub_configmap_name: jupyterhub-custom-cfg
     notebook_images:


### PR DESCRIPTION
This should be paired with the ODH 0.5.2 release to work properly.

Changes:
* Adds ODH CR variable `jupyterhub_img_tag` to pin the jupyterhub image to a tagged version. If this var is absent, it will default to `latest`
* Fixes the custom singleuser profiles w/ `spark` services defined to match the format that is compatible with the pinned jupyterhub release