### PR TITLE
adding ImageStream for openshift sme mailing list analysis work 

### DIFF
--- a/applications/jupyterhub/bases/custom-images/jupyterhub-custom-images.yaml
+++ b/applications/jupyterhub/bases/custom-images/jupyterhub-custom-images.yaml
@@ -172,6 +172,25 @@ spec:
 
 # AIOps Data Sci Demo images
 
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "true" 
+  name: s2i-openshift-sme-mailing-list-analysis-notebook
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - from:
+      kind: DockerImage
+      name: docker-registry.upshift.redhat.com/aicoe-notebooks/openshift-sme-mailing-list-analysis:latest
+    importPolicy:
+      scheduled: true
+    name: "latest"
+
+
 ## OCP4 Anomaly Detection Image from https://gitlab.cee.redhat.com/AICoE/ocp4
 ---
 apiVersion: image.openshift.io/v1


### PR DESCRIPTION
This PR updates `applications/jupyterhub/bases/custom-images/jupyterhub-custom-images.yaml` to include notebooks from the [openshift sme mailing list analysis repo](https://github.com/aicoe-aiops/openshift-sme-mailing-list-analysis) into the teams options of jupyterhub images. 