### PR TITLE
Fix jupyterhub membership

### DIFF
--- a/applications/jupyterhub/overlays/prod/membership.yaml
+++ b/applications/jupyterhub/overlays/prod/membership.yaml
@@ -7,7 +7,7 @@ roleRef:
   name: admin
 subjects:
   - kind: 'Group'
-    name: data-hub-admins
+    name: data-hub-openshift-admins
 ---
 apiVersion: authorization.openshift.io/v1
 kind: RoleBinding
@@ -17,6 +17,4 @@ roleRef:
   name: view
 subjects:
   - kind: 'Group'
-    name: data-hub
-  - kind: 'User'
-    name: shanand
+    name: system:authenticated

--- a/applications/jupyterhub/overlays/stage/membership.yaml
+++ b/applications/jupyterhub/overlays/stage/membership.yaml
@@ -7,5 +7,5 @@ roleRef:
   name: admin
 subjects:
   - kind: 'Group'
-    name: data-hub
+    name: data-hub-openshift-admins
     


### PR DESCRIPTION
Updating the jupyterhub membership to have the correct mapping of admin/view roles to their appropriate groups