### PR TITLE
Add aggregated cluster roles for Argo and Argo Events

### DIFF
--- a/applications/argo-events/base/kustomization.yaml
+++ b/applications/argo-events/base/kustomization.yaml
@@ -4,3 +4,7 @@ kind: Kustomization
 resources:
   - ./argo-events-user-role.yaml
   - github.com/argoproj/argo-events/manifests/namespace-install?ref=v0.16.0
+  - https://raw.githubusercontent.com/argoproj/argo-events/v0.16.0/manifests/cluster-install/rbac/argo-events-aggregate-to-admin.yaml
+  - https://raw.githubusercontent.com/argoproj/argo-events/v0.16.0/manifests/cluster-install/rbac/argo-events-aggregate-to-edit.yaml
+  - https://raw.githubusercontent.com/argoproj/argo-events/v0.16.0/manifests/cluster-install/rbac/argo-events-aggregate-to-view.yaml
+#

--- a/applications/argo/base/kustomization.yaml
+++ b/applications/argo/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ./argo-server-route.yaml
   - ./workflow-controller-metrics-route.yaml
   - github.com/argoproj/argo/manifests/namespace-install?ref=v2.8.2
+  - https://raw.githubusercontent.com/argoproj/argo/v2.8.2/manifests/cluster-install/workflow-controller-rbac/workflow-aggregate-roles.yaml
 
 patchesStrategicMerge:
   - ./workflow-controller-configmap.yaml


### PR DESCRIPTION
Aggregated cluster roles allows Argo CD to discover CRDs on namespaces where it has admin/edit/view access without a need to define any additional per overlay/namespace roles, therefore it won't fail when discovering these resources in namespaces which don't plan on using these CRDs - therefore won't define any special roles for them.