### PR TITLE
Add ArgoCD RoleBinding for Argo and Argo Events

### DIFF
--- a/applications/argo-events/overlays/dh-prod-argo/membership.yaml
+++ b/applications/argo-events/overlays/dh-prod-argo/membership.yaml
@@ -31,3 +31,14 @@ subjects:
     name: data-hub-admins
   - kind: Group
     name: data-hub
+---
+apiVersion: authorization.openshift.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-manager-rolebinding
+roleRef:
+  name: admin
+subjects:
+  - kind: ServiceAccount
+    name: argocd-manager
+    namespace: argocd-manager

--- a/applications/argo-events/overlays/dh-stage-argo/membership.yaml
+++ b/applications/argo-events/overlays/dh-stage-argo/membership.yaml
@@ -19,3 +19,14 @@ roleRef:
 subjects:
   - kind: Group
     name: data-hub
+---
+apiVersion: authorization.openshift.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-manager-rolebinding
+roleRef:
+  name: admin
+subjects:
+  - kind: ServiceAccount
+    name: argocd-manager
+    namespace: argocd-manager

--- a/applications/argo/overlays/dh-prod-argo/membership.yaml
+++ b/applications/argo/overlays/dh-prod-argo/membership.yaml
@@ -31,3 +31,14 @@ subjects:
     name: data-hub-admins
   - kind: Group
     name: data-hub
+---
+apiVersion: authorization.openshift.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-manager-rolebinding
+roleRef:
+  name: admin
+subjects:
+  - kind: ServiceAccount
+    name: argocd-manager
+    namespace: argocd-manager

--- a/applications/argo/overlays/dh-stage-argo/membership.yaml
+++ b/applications/argo/overlays/dh-stage-argo/membership.yaml
@@ -19,3 +19,14 @@ roleRef:
 subjects:
   - kind: Group
     name: data-hub
+---
+apiVersion: authorization.openshift.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-manager-rolebinding
+roleRef:
+  name: admin
+subjects:
+  - kind: ServiceAccount
+    name: argocd-manager
+    namespace: argocd-manager


### PR DESCRIPTION
Required by https://github.com/AICoE/aicoe-cd/pull/45

Adds ArgoCD RoleBinding to the VCS.