### PR TITLE
Fix Argo[-events] role bindings apiGroup

### DIFF
--- a/applications/argo-events/base/argo-events-user-role.yaml
+++ b/applications/argo-events/base/argo-events-user-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: authorization.openshift.io/v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: argo-events-user

--- a/applications/argo-events/overlays/dh-prod-argo/membership.yaml
+++ b/applications/argo-events/overlays/dh-prod-argo/membership.yaml
@@ -1,4 +1,4 @@
-apiVersion: authorization.openshift.io/v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: project-admins
@@ -8,7 +8,7 @@ subjects:
   - kind: Group
     name: data-hub-admins
 ---
-apiVersion: authorization.openshift.io/v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: project-viewers
@@ -18,7 +18,7 @@ subjects:
   - kind: Group
     name: data-hub
 ---
-apiVersion: authorization.openshift.io/v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: project-argo-events-users
@@ -32,7 +32,7 @@ subjects:
   - kind: Group
     name: data-hub
 ---
-apiVersion: authorization.openshift.io/v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: argocd-manager-rolebinding

--- a/applications/argo-events/overlays/dh-stage-argo/membership.yaml
+++ b/applications/argo-events/overlays/dh-stage-argo/membership.yaml
@@ -1,4 +1,4 @@
-apiVersion: authorization.openshift.io/v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: project-admins
@@ -8,7 +8,7 @@ subjects:
   - kind: Group
     name: data-hub
 ---
-apiVersion: authorization.openshift.io/v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: project-argo-events-users
@@ -20,7 +20,7 @@ subjects:
   - kind: Group
     name: data-hub
 ---
-apiVersion: authorization.openshift.io/v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: argocd-manager-rolebinding

--- a/applications/argo/base/argo-user-role.yaml
+++ b/applications/argo/base/argo-user-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: authorization.openshift.io/v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: argo-user

--- a/applications/argo/overlays/dh-stage-argo/membership.yaml
+++ b/applications/argo/overlays/dh-stage-argo/membership.yaml
@@ -1,4 +1,4 @@
-apiVersion: authorization.openshift.io/v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: project-admins
@@ -8,7 +8,7 @@ subjects:
   - kind: Group
     name: data-hub
 ---
-apiVersion: authorization.openshift.io/v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: project-argo-users
@@ -20,7 +20,7 @@ subjects:
   - kind: Group
     name: data-hub
 ---
-apiVersion: authorization.openshift.io/v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: argocd-manager-rolebinding


### PR DESCRIPTION
Mixing `authorization.openshift.io` and `rbac.authorization.k8s.io` apiGroups causes issues for rolebindings accessing namespaced roles. This PR fixes argo and argo events rolebinding deployments.

Note: this doesn't fix `role` creation failures - that is caused by missing permissions in project admin cluster roles - project admin can't grant permissions it doesn't have. This will be solved via PSI ticket.