### PR TITLE
Fix Argo[-events] role bindings again - part 2

### DIFF
--- a/applications/argo-events/overlays/dh-prod-argo/membership.yaml
+++ b/applications/argo-events/overlays/dh-prod-argo/membership.yaml
@@ -1,30 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: project-admins
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: admin
-subjects:
-  - kind: Group
-    name: data-hub-admins
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: project-viewers
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: view
-subjects:
-  - kind: Group
-    name: data-hub
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
   name: project-argo-events-users
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -35,16 +11,3 @@ subjects:
     name: data-hub-admins
   - kind: Group
     name: data-hub
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: argocd-manager-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: admin
-subjects:
-  - kind: ServiceAccount
-    name: argocd-manager
-    namespace: argocd-manager

--- a/applications/argo-events/overlays/dh-stage-argo/membership.yaml
+++ b/applications/argo-events/overlays/dh-stage-argo/membership.yaml
@@ -1,18 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: project-admins
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: admin
-subjects:
-  - kind: Group
-    name: data-hub
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
   name: project-argo-events-users
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -21,16 +9,3 @@ roleRef:
 subjects:
   - kind: Group
     name: data-hub
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: argocd-manager-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: admin
-subjects:
-  - kind: ServiceAccount
-    name: argocd-manager
-    namespace: argocd-manager


### PR DESCRIPTION
I don't like to repeat myself, but yeah.. they are fighting. Resolving that by removing those rolebindings from Argo-Events, since they are being deployed to the same namespace (though with different labels) via the Argo app.


![image](https://user-images.githubusercontent.com/7453394/90534228-c7f16580-e179-11ea-9b60-e49a4fd8f31b.png)
